### PR TITLE
Add default database fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ If you encounter database-related errors (missing tables or issues inserting dat
 python manage.py makemigrations
 python manage.py migrate
 ```
+
+To initialize the database with sample data, run:
+
+```shell
+python manage.py loaddata parking/fixtures/default
+```
+
 ### 4. Running the Development Server
 To start the application and view it in your browser, run:
 ```shell

--- a/parking/fixtures/default.yaml
+++ b/parking/fixtures/default.yaml
@@ -2,6 +2,42 @@
 DEFAULT_TS: &default_ts '2026-04-22T08:00:00Z'
 ---
 
+- model: auth.user
+  pk: 1
+  fields:
+    username: testuser1
+    email: testuser1@example.com
+    first_name: Test
+    last_name: User One
+    password: FAKE_LOGIN
+    is_staff: false
+    is_active: true
+    is_superuser: false
+
+- model: auth.user
+  pk: 2
+  fields:
+    username: testuser2
+    email: testuser2@example.com
+    first_name: Test
+    last_name: User Two
+    password: FAKE_LOGIN
+    is_staff: false
+    is_active: true
+    is_superuser: false
+
+- model: auth.user
+  pk: 3
+  fields:
+    username: testuser3
+    email: testuser3@example.com
+    first_name: Test
+    last_name: User Three
+    password: FAKE_LOGIN
+    is_staff: false
+    is_active: true
+    is_superuser: false
+
 - model: parking.parkinglot
   pk: 1
   fields:

--- a/parking/fixtures/default.yaml
+++ b/parking/fixtures/default.yaml
@@ -5,7 +5,7 @@
     email: testuser1@example.com
     first_name: Test
     last_name: User One
-    password: !FAKE_LOGIN
+    password: FAKE_LOGIN
     is_staff: false
     is_active: true
     is_superuser: false
@@ -17,7 +17,7 @@
     email: testuser2@example.com
     first_name: Test
     last_name: User Two
-    password: !FAKE_LOGIN
+    password: FAKE_LOGIN
     is_staff: false
     is_active: true
     is_superuser: false
@@ -29,7 +29,7 @@
     email: testuser3@example.com
     first_name: Test
     last_name: User Three
-    password: !FAKE_LOGIN
+    password: FAKE_LOGIN
     is_staff: false
     is_active: true
     is_superuser: false

--- a/parking/fixtures/default.yaml
+++ b/parking/fixtures/default.yaml
@@ -5,7 +5,7 @@
     email: testuser1@example.com
     first_name: Test
     last_name: User One
-    password: FAKE_LOGIN
+    password: !FAKE_LOGIN
     is_staff: false
     is_active: true
     is_superuser: false
@@ -17,7 +17,7 @@
     email: testuser2@example.com
     first_name: Test
     last_name: User Two
-    password: FAKE_LOGIN
+    password: !FAKE_LOGIN
     is_staff: false
     is_active: true
     is_superuser: false
@@ -29,7 +29,7 @@
     email: testuser3@example.com
     first_name: Test
     last_name: User Three
-    password: FAKE_LOGIN
+    password: !FAKE_LOGIN
     is_staff: false
     is_active: true
     is_superuser: false

--- a/parking/fixtures/default.yaml
+++ b/parking/fixtures/default.yaml
@@ -93,3 +93,30 @@ DEFAULT_TS: &default_ts '2026-04-22T08:00:00Z'
     name: Lot L
     created_at: *default_ts
     updated_at: *default_ts
+
+- model: parking.parkingsession
+  pk: 1
+  fields:
+    lot: 1
+    user: 1
+    occupied_at: '2026-04-22T10:00:00Z'
+    ended_at: null
+    updated_at: '2026-04-22T10:00:00Z'
+
+- model: parking.parkingsession
+  pk: 2
+  fields:
+    lot: 2
+    user: 2
+    occupied_at: '2026-04-22T09:30:00Z'
+    ended_at: '2026-04-22T11:00:00Z'
+    updated_at: '2026-04-22T11:00:00Z'
+
+- model: parking.parkingsession
+  pk: 3
+  fields:
+    lot: 3
+    user: 3
+    occupied_at: '2026-04-21T14:20:00Z'
+    ended_at: '2026-04-21T16:45:00Z'
+    updated_at: '2026-04-21T16:45:00Z'

--- a/parking/fixtures/default.yaml
+++ b/parking/fixtures/default.yaml
@@ -1,0 +1,55 @@
+- model: parking.parkinglot
+  pk: 1
+  fields:
+    name: Lot A
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
+
+- model: parking.parkinglot
+  pk: 2
+  fields:
+    name: Lot B
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
+
+- model: parking.parkinglot
+  pk: 3
+  fields:
+    name: Lot D
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
+
+- model: parking.parkinglot
+  pk: 4
+  fields:
+    name: Lot E
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
+
+- model: parking.parkinglot
+  pk: 5
+  fields:
+    name: Lot G
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
+
+- model: parking.parkinglot
+  pk: 6
+  fields:
+    name: Lot J
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
+
+- model: parking.parkinglot
+  pk: 7
+  fields:
+    name: Lot K
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
+
+- model: parking.parkinglot
+  pk: 8
+  fields:
+    name: Lot L
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'

--- a/parking/fixtures/default.yaml
+++ b/parking/fixtures/default.yaml
@@ -1,55 +1,59 @@
+---
+DEFAULT_TS: &default_ts '2026-04-22T08:00:00Z'
+---
+
 - model: parking.parkinglot
   pk: 1
   fields:
     name: Lot A
-    created_at: '2026-04-22T08:00:00Z'
-    updated_at: '2026-04-22T08:00:00Z'
+    created_at: *default_ts
+    updated_at: *default_ts
 
 - model: parking.parkinglot
   pk: 2
   fields:
     name: Lot B
-    created_at: '2026-04-22T08:00:00Z'
-    updated_at: '2026-04-22T08:00:00Z'
+    created_at: *default_ts
+    updated_at: *default_ts
 
 - model: parking.parkinglot
   pk: 3
   fields:
     name: Lot D
-    created_at: '2026-04-22T08:00:00Z'
-    updated_at: '2026-04-22T08:00:00Z'
+    created_at: *default_ts
+    updated_at: *default_ts
 
 - model: parking.parkinglot
   pk: 4
   fields:
     name: Lot E
-    created_at: '2026-04-22T08:00:00Z'
-    updated_at: '2026-04-22T08:00:00Z'
+    created_at: *default_ts
+    updated_at: *default_ts
 
 - model: parking.parkinglot
   pk: 5
   fields:
     name: Lot G
-    created_at: '2026-04-22T08:00:00Z'
-    updated_at: '2026-04-22T08:00:00Z'
+    created_at: *default_ts
+    updated_at: *default_ts
 
 - model: parking.parkinglot
   pk: 6
   fields:
     name: Lot J
-    created_at: '2026-04-22T08:00:00Z'
-    updated_at: '2026-04-22T08:00:00Z'
+    created_at: *default_ts
+    updated_at: *default_ts
 
 - model: parking.parkinglot
   pk: 7
   fields:
     name: Lot K
-    created_at: '2026-04-22T08:00:00Z'
-    updated_at: '2026-04-22T08:00:00Z'
+    created_at: *default_ts
+    updated_at: *default_ts
 
 - model: parking.parkinglot
   pk: 8
   fields:
     name: Lot L
-    created_at: '2026-04-22T08:00:00Z'
-    updated_at: '2026-04-22T08:00:00Z'
+    created_at: *default_ts
+    updated_at: *default_ts

--- a/parking/fixtures/default.yaml
+++ b/parking/fixtures/default.yaml
@@ -1,7 +1,3 @@
----
-DEFAULT_TS: &default_ts '2026-04-22T08:00:00Z'
----
-
 - model: auth.user
   pk: 1
   fields:
@@ -42,57 +38,57 @@ DEFAULT_TS: &default_ts '2026-04-22T08:00:00Z'
   pk: 1
   fields:
     name: Lot A
-    created_at: *default_ts
-    updated_at: *default_ts
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
 
 - model: parking.parkinglot
   pk: 2
   fields:
     name: Lot B
-    created_at: *default_ts
-    updated_at: *default_ts
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
 
 - model: parking.parkinglot
   pk: 3
   fields:
     name: Lot D
-    created_at: *default_ts
-    updated_at: *default_ts
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
 
 - model: parking.parkinglot
   pk: 4
   fields:
     name: Lot E
-    created_at: *default_ts
-    updated_at: *default_ts
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
 
 - model: parking.parkinglot
   pk: 5
   fields:
     name: Lot G
-    created_at: *default_ts
-    updated_at: *default_ts
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
 
 - model: parking.parkinglot
   pk: 6
   fields:
     name: Lot J
-    created_at: *default_ts
-    updated_at: *default_ts
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
 
 - model: parking.parkinglot
   pk: 7
   fields:
     name: Lot K
-    created_at: *default_ts
-    updated_at: *default_ts
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
 
 - model: parking.parkinglot
   pk: 8
   fields:
     name: Lot L
-    created_at: *default_ts
-    updated_at: *default_ts
+    created_at: '2026-04-22T08:00:00Z'
+    updated_at: '2026-04-22T08:00:00Z'
 
 - model: parking.parkingsession
   pk: 1


### PR DESCRIPTION
# Add default database fixtures

## Description

Added initial YAML fixture data to populate the database for testing. This includes test users, parking lots, and parking sessions so that developers don't need to manually create records through the admin panel.

## Related Issue

closes #14

## Motivation and Context

We needed a way to quickly populate the database with test data without having to manually create records through Django admin. This fixture provides test data that can be loaded with a single command.

## How Has This Been Tested?

- Ran migrations to set up schema
- Successfully loaded fixture with: `python manage.py loaddata parking/fixtures/default.yaml`
- Verified data loads correctly (3 users, 8 parking lots, 3 parking sessions)
- Tested that fixture can be reloaded without conflicts

## Files Changed

- `parking/fixtures/default.yaml` - New fixture file with default test data