### PR TITLE
Removing logout button on login page, adding white boxes in for visib…

### DIFF
--- a/features/accounts/forms.py
+++ b/features/accounts/forms.py
@@ -2,12 +2,18 @@ from django import forms
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import UserCreationForm
 
-#Override the default registration form to include email input.
+input_class = 'block w-full rounded-md bg-white px-3 py-2 text-gray-900 text-sm outline outline-1 outline-gray-300'
+
 class RegisterForm(UserCreationForm):
-    name = forms.CharField(label="Name", max_length=100)
-    username = forms.CharField(label="Username", max_length=100)
-    email = forms.EmailField(required=True)
+    name = forms.CharField(label="Name", max_length=100, widget=forms.TextInput(attrs={'class': input_class}))
+    username = forms.CharField(label="Username", max_length=100, widget=forms.TextInput(attrs={'class': input_class}))
+    email = forms.EmailField(required=True, widget=forms.EmailInput(attrs={'class': input_class}))
 
     class Meta:
         model = User
         fields = ["name", "username", "email", 'password1', 'password2']
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['password1'].widget.attrs.update({'class': input_class})
+        self.fields['password2'].widget.attrs.update({'class': input_class})

--- a/features/accounts/urls.py
+++ b/features/accounts/urls.py
@@ -19,10 +19,14 @@ Including another URLconf
 from django.urls import path
 from django.contrib.auth import views as auth_views
 from features.accounts import views
+from features.accounts.views import StyledAuthenticationForm
 
 # URL paths for register, login and logout pages.
 urlpatterns = [
-    path('login/', auth_views.LoginView.as_view(template_name='accounts/login.html'), name='login'),
+    path('login/', auth_views.LoginView.as_view(
+        template_name='accounts/login.html',
+        authentication_form=StyledAuthenticationForm
+    ), name='login'),
     path('logout/', auth_views.LogoutView.as_view(next_page='/'), name='logout'),
     path('register/', views.register_view, name='register'),
 ]

--- a/features/accounts/views.py
+++ b/features/accounts/views.py
@@ -7,6 +7,16 @@ from django.contrib.auth import authenticate, login, logout
 from django.contrib import messages
 from .forms import RegisterForm
 
+from django.contrib.auth.forms import AuthenticationForm
+
+class StyledAuthenticationForm(AuthenticationForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs.update({
+                'class': 'block w-full rounded-md bg-white px-3 py-2 text-gray-900 text-sm outline outline-1 outline-gray-300'
+            })
+
 #Override register function to redirect user to specific pages.
 def register_view(request):
     if request.method == "POST":

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -68,16 +68,11 @@
 
     </form>
 
-    <!-- Logout Button -->
-    {% if user.is_authenticated %}
-    <form action="{% url 'logout' %}" method="post">
-        {% csrf_token %}
-        <button type="submit"
-                class="flex w-full justify-center rounded-md bg-[#000000] px-3 py-1.5 text-sm leading-6 font-semibold text-white hover:bg-[#666666] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500">
-            Logout
-        </button>
-    </form>
-    {% endif %}
+    <p class="mt-6 text-center text-sm text-gray-300">
+      Don't have an account?
+      <a href="{% url 'register' %}" class="text-white font-semibold hover:text-gray-300">Sign up</a>
+    </p>
+
 
   </div>
 </div>


### PR DESCRIPTION
# Fix Login and Register Page Styling

Description
Made the input fields visible on the login and register pages by adding a `StyledAuthenticationForm` class to apply white background styling to the form inputs. Also added a link from the login page to the register page. Removed "Logout" button from login page, didn't make any sense to have there.


Related Issue
N/A

Motivation and Context
The input fields were invisible against the dark background so users couldn't see where to type. There was also no way to get to the register page from login.

How Has This Been Tested?
Ran the local server and confirmed input fields are visible and the register link works on the login page.